### PR TITLE
print_d: Resource type coverage and project information update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ echo print_d($obj, true); // prints object variables and methods with attribute 
 
 ## Screenshots
 
-![Print_d](https://raw.github.com/vikerlane/print_d/master/example.png)
+![Print_d](https://raw.githubusercontent.com/CesiumComputer/print_d/master/example.png)

--- a/print_d.php
+++ b/print_d.php
@@ -4,9 +4,10 @@
 
 Kratt Tools PRINT_D
 Written by Pertti Soomann, 2014
+https://github.com/vikerlane
 
 Check for latest version and report issues at
-https://github.com/vikerlane/print_d
+https://github.com/CesiumComputer/print_d
 
 Copyright (c) 2014, Pertti Soomann @ Vikerlane
 All rights reserved.
@@ -69,6 +70,7 @@ function print_d($var, $options = false)
 		'type-string' => 'font-weight: bold; max-width: 250px; color: #d00;',
 		'type-boolean' => 'font-weight: bold; max-width: 250px; color: #bbb;',
 		'type-null' => 'font-weight: bold; max-width: 250px; color: #bbb;',
+		'type-resource' => 'font-weight: bold; max-width: 250px; color: #bbb;',
 		'void' => 'font-style: italic; color: #bbb;',
 		'emptystring' => 'color: #bbb; font-style: italic; font-weight: normal;'
 	);


### PR DESCRIPTION
When I previewed an object that contains resource type the following message is shown:

```
Severity: Notice
Message: Undefined index: type-resource
Filename: bootstrap/print_d.php
Line Number: 181
```

For fixing this issue I've added a line within the styling definitions.

Also, I've updated some information about this project.